### PR TITLE
Blanket ignoring of all mentions in home timeline can be disabled

### DIFF
--- a/twitterbot/bot.py
+++ b/twitterbot/bot.py
@@ -48,6 +48,8 @@ class TwitterBot:
         self.config['reply_interval'] = 10
         self.config['reply_interval_range'] = None
 
+        self.config['ignore_timeline_mentions'] = True
+
         self.config['logging_level'] = logging.DEBUG
         self.config['storage'] = FileStorage()
 
@@ -292,8 +294,15 @@ class TwitterBot:
         try:
             current_timeline = self.api.home_timeline(count=200, since_id=self.state['last_timeline_id'])
 
-            # remove all tweets with mentions (heuristically)
-            current_timeline = [t for t in current_timeline if '@' not in t.text and t.author.screen_name.lower() != self.screen_name.lower()]
+            # remove my tweets
+            current_timeline = [t for t in current_timeline if t.author.screen_name.lower() != self.screen_name.lower()]
+
+            # remove all tweets mentioning me
+            current_timeline = [t for t in current_timeline if not re.search('@'+self.screen_name, t.text, flags=re.IGNORECASE)]
+
+            if self.config['ignore_timeline_mentions']:
+                # remove all tweets with mentions (heuristically)
+                current_timeline = [t for t in current_timeline if '@' not in t.text]
 
             if len(current_timeline) != 0:
                 self.state['last_timeline_id'] = current_timeline[0].id


### PR DESCRIPTION
Mentions of the bot itself are still ignored, so they don't get handled twice.
